### PR TITLE
frontend dependecies to devcontainer

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,7 +1,22 @@
-FROM ghcr.io/tgoelles/python_docker:v0.3.1_py3.8
+FROM ghcr.io/tgoelles/python_docker:v0.3.5_py3.8
 
 
 ENV DEBIAN_FRONTEND=noninteractive
+
+
+RUN curl -fsSL https://deb.nodesource.com/setup_current.x | bash - \
+    && apt-get update \
+    # cmdtest incompatible with yarn
+    && apt remove cmdtest \
+    # add packages here like
+    && apt-get -y install nodejs \
+    # Clean up
+    && apt-get autoremove -y \
+    && apt-get clean -y \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN /usr/bin/npm install -g yarn
+
 
 COPY .devcontainer/environment.yml /tmp/conda-tmp/
 RUN /opt/conda/bin/conda env update -n base -f /tmp/conda-tmp/environment.yml

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -25,6 +25,7 @@
 		"python.dataScience.alwaysTrustNotebooks": true,
 		"jupyter.alwaysTrustNotebooks": true
 	},
+	"postCreateCommand": "cd /workspaces/BioSNICAR_GO_PY/app/src && yarn",
 	"extensions": [
 		"ms-python.python",
 		"njpwerner.autodocstring",
@@ -37,5 +38,5 @@
 		"oderwat.indent-rainbow",
 		"gua.rainbow-brackets",
 		"ms-python.vscode-pylance"
-	],
+	]
 }

--- a/.devcontainer/environment.yml
+++ b/.devcontainer/environment.yml
@@ -15,4 +15,8 @@ dependencies:
       - seaborn
       - plotnine
       - pre-commit
+      - flask
+      - gunicorn
+      - requests
+      - flask-cors
 prefix: /opt/conda

--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,7 @@ __pycache__/
 
 # test output
 py_mat_comparison.png
+
+# nodejs
+yarn.lock
+node_modules/.yarn-integrity


### PR DESCRIPTION
Hi,

I added the frontend dependencies to the docker devcontainer.
This makes it easier to get started.

Now it is possible to develop and run the app with:

In a terminal, navigate to the top-level BioSNICAR directory and run:

python ./app/api/app.py

This starts the Flask server running on localhost:5000. You can now ignore this and open a new terminal window (leaving the original terminal running in the background).

In the new terminal navigate to /app/src/ and run:

yarn start

---
so no installations required.

This should also make it easy to deploy the app somewhere by using the docker in the future. 