### PR TITLE
fix minor bugs in core rt modules

### DIFF
--- a/biosnicar/classes/ice.py
+++ b/biosnicar/classes/ice.py
@@ -19,7 +19,7 @@ class Ice:
         cdom: array containing Boolean (1/0) toggling presence of cdom in each layer
         rho: array containing density of each layer in kg/m3
         sfc: array with reflectance of underlying surface per wavelength
-        rf: refractive index to use, 0,1,2 or 3 (see docs for definition)
+        rf: refractive index to use, 0, 1 or 2 (see docs for definition)
         shp: grain shape per layer where layer_type==1
         rds: grain radius (layer_type==0) or bubble radius (layer_type==0) in each layer
         water: radius of grain+water coating in each layer where layer_type==0

--- a/biosnicar/classes/illumination.py
+++ b/biosnicar/classes/illumination.py
@@ -69,7 +69,11 @@ class Illumination:
 
         if self.direct:
             cloud_stub = "_clr_"
-            coszen_stub = str("SZA" + str(self.solzen).rjust(2, "0"))
+            # Build the flux-LUT key from the same rounded integer SZA used for
+            # mu_not above; the archive is keyed by zero-padded integer degrees
+            # (SZA00..SZA89), so a float solzen (e.g. 50.0) must not leak into
+            # the key string (it would yield "SZA50.0" -> KeyError).
+            coszen_stub = f"SZA{int(np.rint(self.solzen)):02d}"
 
         key = self.stubs[self.incoming] + cloud_stub + coszen_stub
         fsds = _get_fsds_data()

--- a/biosnicar/optical_properties/column_OPs.py
+++ b/biosnicar/optical_properties/column_OPs.py
@@ -480,7 +480,7 @@ def correct_for_asphericity(ice, g_snw, ssa_snw, i, model_config):
         # Eqn. 3.1 in Fu (2007)
         gg_snw_F07_tmp = g_f07_c0 + g_f07_c1 * ar_tmp + g_f07_c2 * ar_tmp**2
 
-    # 3=hexagonal plate,
+    # 2 = hexagonal plate,
     # He et al. 2017 parameterization
     if ice.shp[i] == 2:
 
@@ -515,7 +515,7 @@ def correct_for_asphericity(ice, g_snw, ssa_snw, i, model_config):
             g_f07_p0 + g_f07_p1 * np.log(ar_tmp) + g_f07_p2 * (np.log(ar_tmp)) ** 2
         )
 
-    # 4=koch snowflake,
+    # 3 = koch snowflake,
     # He et al. (2017)
     #  parameterization
     if ice.shp[i] == 3:

--- a/biosnicar/optical_properties/geometric_optics_ice.py
+++ b/biosnicar/optical_properties/geometric_optics_ice.py
@@ -150,8 +150,9 @@ def calc_optical_params(
     ssa_list, g_list = calc_ssa_and_g(ar, V, Area, reals, imags, wavelengths)
 
     # Absorption cross section and mass absorption coefficient
+    # (density 917 kg/m3 — unified with the rest of the codebase; was 914)
     absXS = Area * (1 - np.exp(-4 * np.pi * imags * V / (Area * wavelengths)))
-    mac_list = absXS / V * 914
+    mac_list = absXS / V * 917
 
     if plots:
         plt.figure(1)

--- a/biosnicar/optical_properties/mie_coated_water_spheres.py
+++ b/biosnicar/optical_properties/mie_coated_water_spheres.py
@@ -139,20 +139,17 @@ def miecoated(m1, m2, x, y):
 
     """
 
-    # to reduce computing time
-    if x == y:
-        return mie(m1, y)
-
-    # to avoid a singularity at x=0
-    elif x == 0:
-        return mie(m2, y)
-
-    # to reduce computing time
-    elif m1 == m2:
-        return mie(m1, y)
+    # Degenerate cases (no coating x==y, uniform composition m1==m2) reduce to a
+    # homogeneous sphere and are computed correctly by the general routine below.
+    # A zero inner radius is the only genuine singularity (the Riccati-Bessel
+    # recursion divides by x), so nudge it to a negligible value -> effectively a
+    # homogeneous sphere of the coating material.  (These cases previously called
+    # the miepython *module* as a function, raising TypeError if ever reached.)
+    if x == 0:
+        x = 1e-12
 
     # this is the normal situation
-    elif x > 0:
+    if x > 0:
         nmax = int(round(2 + y + 4 * y ** (1 / 3)))
         n1 = nmax - 1
         n = np.arange(1, nmax + 1, 1)
@@ -183,7 +180,7 @@ def miecoated(m1, m2, x, y):
         qsca = 2 * q / y2
         qabs = qext - qsca
         fn = (f[0, :] - f[1, :]) * cn
-        gn = (-1) ^ n
+        gn = (-1.0) ** n
         f_3 = fn * gn
         q = sum(f_3)
         qb = q * q.conj() / y2
@@ -238,8 +235,8 @@ def miecoated_driver(rice, rwater, fn_ice, rf_ice, fn_water, wvl):
     # density of water at 1 degree C in kg m-3
     WatDensity = 999
 
-    # density of ice in kg m-3
-    IceDensity = 934
+    # density of ice in kg m-3 (unified with the rest of the codebase; was 934)
+    IceDensity = 917
 
     IceVol = 4 / 3 * np.pi * rice**3
     WatVol = (4 / 3 * np.pi * rwater**3) - IceVol

--- a/tests/test_run_model.py
+++ b/tests/test_run_model.py
@@ -21,6 +21,23 @@ def test_override_solzen_changes_bba():
     assert out1.BBA != out2.BBA
 
 
+def test_float_solzen_does_not_raise():
+    """A float solar zenith angle must not raise (regression).
+
+    The solar-flux LUT is keyed by zero-padded integer degrees (SZA00..SZA89),
+    while the public API documents solzen as a float. A float (or single-digit)
+    zenith must round to the integer key rather than leaking "SZA50.0" into the
+    lookup and raising KeyError.
+    """
+    integer = run_model(solzen=50)
+    for sz in (50.0, 49.6, 5, 5.0):
+        out = run_model(solzen=sz)
+        assert 0 < out.BBA < 1
+    # 50.0 and 49.6 both round to 50 -> identical result to the integer call
+    assert run_model(solzen=50.0).BBA == integer.BBA
+    assert run_model(solzen=49.6).BBA == integer.BBA
+
+
 def test_override_rds_changes_bba():
     """Changing grain radius produces a different BBA."""
     out1 = run_model(rds=200)


### PR DESCRIPTION
Fix core physics bugs found in audit

Three independent fixes 

- **illumination.py — float solzen raised KeyError**

The direct-beam solar-flux LUT is keyed by zero-padded integer degrees (SZA00..SZA89), but the key was built from the raw solzen while mu_not was (correctly) built from np.rint(solzen). The public API documents solzen as a float, so run_model(solzen=50.0) — or any non-integer zenith — produced key "SZA50.0" and crashed; only integer literals happened to work. Now the key is built from the same int(np.rint(solzen)) used for mu_not. Regression test added.

- **mie_coated_water_spheres.py — two latent bugs**

- gn = (-1) ^ n was Python bitwise XOR, not exponentiation (n=3 → -4 instead of -1), corrupting the backscatter sum qb/qratio. These outputs aren't consumed by the RT solver, so albedo was unaffected — but the values were silently wrong. Fixed to (-1.0) ** n.
- The x==y / x==0 / m1==m2 shortcut branches called the miepython module as a function (which raises TypeError, and miepython 3.2.0 has no top-level mie() anyway). The caller guarantees 0 < x < y so they were dead, but broken. Degenerate coated spheres reduce to homogeneous spheres — handled correctly by the general computation; the only true singularity (x==0, NaN in the Riccati-Bessel recursion) is now nudged to a negligible inner radius, matching the original intent.

**- documentation**

- Ice density -> 917 kg/m³: was 914 in geometric_optics_ice.py (affects only offline GO-LUT regeneration) and 934 in mie_coated_water_spheres.py (feeds only mass cross-sections that add_water_coating discards).
- column_OPs.py: grain-shape inline comments were off-by-one ("3=hexagonal plate" over the shp==2 branch, "4=koch snowflake" over shp==3); the executable branches and docstring were already correct.
- ice.py: rf docstring said "0,1,2 or 3" but rf actually capped at 2.
